### PR TITLE
Include hidden files and dirs when searching

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -253,8 +253,8 @@ let g:tutor_debug=1
 let g:ctrlp_use_caching=0
 
 if executable('rg')
-  let g:ctrlp_user_command='rg %s --files --color never'
-  let g:ackprg='rg --smart-case --no-heading --vimgrep'
+  let g:ctrlp_user_command='rg %s --files --color never --hidden -g !.git'
+  let g:ackprg='rg --smart-case --no-heading --vimgrep --hidden -g !.git'
   let g:ack_apply_qmappings = 1
   let g:ack_qhandler='botright copen | SortQuickfixList'
 elseif executable('ag')


### PR DESCRIPTION
Adds flags to ripgrep to include results from hidden files and
directories. Also adds a flag to ignore the .git directory.