### PR TITLE
Ignores init.vim settings when loading from VSCode

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -1,3 +1,5 @@
+if !exists('g:vscode')
+
 let s:current_filename=expand("<sfile>")
 let s:truecolor=($COLORTERM == "truecolor")
 
@@ -379,3 +381,4 @@ if s:truecolor || has('gui_running')
   let g:terminal_color_15='#ffffff' " white
 endif
 
+endif


### PR DESCRIPTION
Some plugins and settings work with VSCode's native nvim integration
while others do not. This simply avoids loading anything in `init.vim`
when nvim is being used as a backend for VSCode editing. We may be able
to construct an alternative config that works well with VSCode if we
decide it's worth it.