### PR TITLE
Makes vertically aligning on specific syntax easy

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -45,6 +45,8 @@ Plug 'liuchengxu/vim-which-key', { 'commit': 'c5322b2' }
 
 Plug 'dag/vim-fish', { 'commit': '50b95cb' }
 
+Plug 'godlygeek/tabular', { 'commit': '339091a' }
+
 call plug#end()
 
 syntax on
@@ -208,6 +210,15 @@ endfunction
 let g:which_key_map.M = "which_key_ignore"
 
 vnoremap <silent> <Leader>js !jq .<CR>
+
+" Easy vertical alignment on common syntactic elements.
+" Handy for aligning case blocks on (->), record definitions on (::), etc.
+" In visual mode, just type leader then the punctuation you want to align on
+let g:haskell_tabular = 1
+vnoremap <leader>= :Tabularize /=<CR>
+vnoremap <leader>:: :Tabularize /::<CR>
+vnoremap <leader>-> :Tabularize /-><CR>
+vnoremap <leader>, :Tabularize /,<CR>
 
 tnoremap <Esc> <C-\><C-n>
 tnoremap <C-o> <Esc>

--- a/init.vim
+++ b/init.vim
@@ -215,10 +215,10 @@ vnoremap <silent> <Leader>js !jq .<CR>
 " Handy for aligning case blocks on (->), record definitions on (::), etc.
 " In visual mode, just type leader then the punctuation you want to align on
 let g:haskell_tabular = 1
-vnoremap <leader>= :Tabularize /=<CR>
-vnoremap <leader>:: :Tabularize /::<CR>
-vnoremap <leader>-> :Tabularize /-><CR>
-vnoremap <leader>, :Tabularize /,<CR>
+vnoremap <leader>o= :Tabularize /=<CR>
+vnoremap <leader>o:: :Tabularize /::<CR>
+vnoremap <leader>o-> :Tabularize /-><CR>
+vnoremap <leader>o, :Tabularize /,<CR>
 
 tnoremap <Esc> <C-\><C-n>
 tnoremap <C-o> <Esc>


### PR DESCRIPTION
It's fairly common to e.g. align all blocks under a case on the `->`
arrow, or all types in a record by the `::`. This change adds a plugin
that does that nicely when you select the block in visual mode. I noticed this kind of manual formatting was taking a bit of time during pairing

No idea if this might interfere with anything else, so outside testing/comments are appreciated. (Or maybe this functionality might already exist somewhere in the depths of vimstone)

We might also consider adding other syntax: e.g. `.=` or `<*>` or `$` but these are the bits of punctuation I've found most useful to align on so far