### PR TITLE
Adds shortcuts for recompiling

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -225,6 +225,8 @@ let g:which_key_map = {
   \   't' : [':LspRestart', 'Restart LSP Server'],
   \   's' : [':LspStart', 'Start LSP Server'],
   \   'x' : [':LspStop', 'Stop LSP Server'],
+  \   'h' : [':call chansend(g:last_terminal_chan_id, ":r\<cr>")', 'Recompile in GHCI - send :r to the terminal'],
+  \   'p' : [':call chansend(g:last_terminal_chan_id, "grunt\<cr>")', 'Recompile Purescript - send grunt to the terminal'],
   \   },
   \ 'o' : {
   \   'name' : '+organize',
@@ -468,3 +470,11 @@ augroup InitDotVimLSP
 augroup END
 
 " END lsp related config
+"
+"
+
+augroup Terminal
+  au!
+  au TermOpen * let g:last_terminal_chan_id = b:terminal_job_id
+augroup END
+


### PR DESCRIPTION
`SPC c p` will send "grunt<cr>" to the last opened terminal. This recompiles
Purescript code in our projects that use it.

`SPC c h` will send ":r<cr>" to the last opened terminal. This
recompiles Haskell code in ghci.