### PR TITLE
Adds BufferFileBrowse() fn and key mapping

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -148,6 +148,18 @@ endfunction
 
 command! -nargs=0 GitBlame call s:GitBlame()
 
+"
+" Command to find files from the current buffer's directory and below.
+" A scoped find_files
+"
+function BufferFileBrowse()
+lua <<LUA
+  local file_dirname = vim.fn.expand "%:h:p"
+  require("telescope.builtin").file_browser { cwd = file_dirname }
+LUA
+endfunction
+
+
 let mapleader=" "
 
 " These mappings cannot be configured via which-key because it an incomplete
@@ -206,6 +218,7 @@ let g:which_key_map = {
   \   },
   \ 'f' : {
   \   'name' : '+file',
+  \   'b' : [':call BufferFileBrowse()', 'Open the Telescope file browser from the point of the current buffer.'],
   \   's' : [':write', 'Save the current file'],
   \   'S' : [':wall', 'Save all open current file'],
   \   'r' : [':Telescope oldfiles', 'Switch to a recently opened file'],


### PR DESCRIPTION
This adds a shortcut that launches Telescope's `file_browser` picker
scoped to the directory of the currently active buffer. This makes for
faster searching if you're just looking for things that are your current
modules descendents *and* allows for creation of sibling files easily.

To create a file with `file_browser`

- Launch if with SPC-f-b
- Type the file name in
- Press CTRL-e

Otherwise files can be searched for similar to the normal fuzzy finder
(bound to SPC-a) except child directories won't be searched.