### PR TITLE
Updates plugins to latest versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ An unassuming Neovim distribution used by Flipstone and friends
 
 ## Installation
 
-* Make sure you have Neovim (`nvim`) installed
+* Make sure you have Neovim (`nvim`) installed.
+  * Vimstone currently targets v0.7.2 of Neovim
 * Make sure you have Ripgrep (`rg`) installed
-* Make sure you have Node installed
 
 * Clone the repo: `git clone git@github.com:flipstone/vimstone.git ~/.config/nvim`
 * Run `nvim`

--- a/autoload/plug.vim
+++ b/autoload/plug.vim
@@ -352,7 +352,7 @@ function! plug#end()
   endif
   let lod = { 'ft': {}, 'map': {}, 'cmd': {} }
 
-  if exists('g:did_load_filetypes')
+  if get(g:, 'did_load_filetypes', 0)
     filetype off
   endif
   for name in g:plugs_order
@@ -2621,26 +2621,34 @@ function! s:preview_commit()
 
   let sha = matchstr(getline('.'), '^  \X*\zs[0-9a-f]\{7,9}')
   if empty(sha)
-    return
+    let name = matchstr(getline('.'), '^- \zs[^:]*\ze:$')
+    if empty(name)
+      return
+    endif
+    let title = 'HEAD@{1}..'
+    let command = 'git diff --no-color HEAD@{1}'
+  else
+    let title = sha
+    let command = 'git show --no-color --pretty=medium '.sha
+    let name = s:find_name(line('.'))
   endif
 
-  let name = s:find_name(line('.'))
   if empty(name) || !has_key(g:plugs, name) || !isdirectory(g:plugs[name].dir)
     return
   endif
 
   if exists('g:plug_pwindow') && !s:is_preview_window_open()
     execute g:plug_pwindow
-    execute 'e' sha
+    execute 'e' title
   else
-    execute 'pedit' sha
+    execute 'pedit' title
     wincmd P
   endif
-  setlocal previewwindow filetype=git buftype=nofile nobuflisted modifiable
+  setlocal previewwindow filetype=git buftype=nofile bufhidden=wipe nobuflisted modifiable
   let batchfile = ''
   try
     let [sh, shellcmdflag, shrd] = s:chsh(1)
-    let cmd = 'cd '.plug#shellescape(g:plugs[name].dir).' && git show --no-color --pretty=medium '.sha
+    let cmd = 'cd '.plug#shellescape(g:plugs[name].dir).' && '.command
     if s:is_win
       let [batchfile, cmd] = s:batchfile(cmd)
     endif
@@ -2766,9 +2774,9 @@ function! s:snapshot(force, ...) abort
   1
   let anchor = line('$') - 3
   let names = sort(keys(filter(copy(g:plugs),
-        \'has_key(v:val, "uri") && !has_key(v:val, "commit") && isdirectory(v:val.dir)')))
+        \'has_key(v:val, "uri") && isdirectory(v:val.dir)')))
   for name in reverse(names)
-    let sha = s:git_revision(g:plugs[name].dir)
+    let sha = has_key(g:plugs[name], 'commit') ? g:plugs[name].commit : s:git_revision(g:plugs[name].dir)
     if !empty(sha)
       call append(anchor, printf("silent! let g:plugs['%s'].commit = '%s'", name, sha))
       redraw

--- a/init.vim
+++ b/init.vim
@@ -1,15 +1,19 @@
 let s:current_filename=expand("<sfile>")
 let s:truecolor=($COLORTERM == "truecolor")
 
+" Allow shells started within nvim to detect the server surrounding them
+" (e.g. for nvr)
+let $NVIM_LISTEN_ADDRESS=v:servername
+
 if s:truecolor
   set termguicolors
 endif
 
 call plug#begin('~/.local/share/nvim/plugged')
 
-Plug 'scrooloose/nerdtree', { 'commit': 'eed488b' }
+Plug 'kyazdani42/nvim-tree.lua', { 'commit': '2928f8f' }
 
-Plug 'neomake/neomake', { 'commit': '8df8761' }
+Plug 'neomake/neomake', { 'commit': '0556893' }
 
 Plug 'mileszs/ack.vim', { 'commit': '36e40f9' }
 
@@ -17,19 +21,19 @@ Plug 'flazz/vim-colorschemes', { 'commit': 'fd8f122' }
 
 Plug 'neovimhaskell/haskell-vim', { 'commit': 'f35d022' }
 
-Plug 'purescript-contrib/purescript-vim', { 'commit': 'd493b57' }
+Plug 'purescript-contrib/purescript-vim', { 'commit': 'af5fae0' }
 
-Plug 'fatih/vim-go', { 'commit': '8dfeded' }
+Plug 'fatih/vim-go', { 'commit': '7ec0a19' }
 
 Plug 'ElmCast/elm-vim', { 'commit': '4b71fac' }
 
 Plug 'vmchale/dhall-vim', { 'commit': '68500ef' }
 
-Plug 'sbdchd/neoformat', { 'commit': '0d665b0' }
+Plug 'sbdchd/neoformat', { 'commit': '892be03' }
 
-Plug 'jreybert/vimagit', { 'commit': 'fb71060' }
+Plug 'jreybert/vimagit', { 'commit': '308650d' }
 
-Plug 'tpope/vim-surround', { 'commit': 'aeb9332' }
+Plug 'tpope/vim-surround', { 'commit': 'bf3480d' }
 
 Plug 'tpope/vim-repeat', { 'commit': '24afe92' }
 
@@ -37,26 +41,30 @@ Plug 'gcmt/taboo.vim', { 'commit': 'caf9481' }
 
 Plug 'nicwest/vim-http', { 'commit': 'e642fb9' }
 
-Plug 'liuchengxu/vim-which-key', { 'commit': '165772f' }
+Plug 'liuchengxu/vim-which-key', { 'commit': '654dfc1' }
 
 Plug 'dag/vim-fish', { 'commit': '50b95cb' }
 
 Plug 'godlygeek/tabular', { 'commit': '339091a' }
 
-Plug 'neovim/nvim-lspconfig', { 'commit': '4bcc485' }
+Plug 'neovim/nvim-lspconfig', { 'commit': '99596a8' }
 
 " BEGIN telescope dependencies
 Plug 'nvim-lua/popup.nvim', { 'commit': 'b7404d3' }
-Plug 'nvim-lua/plenary.nvim', { 'commit': '563d9f6' }
+Plug 'nvim-lua/plenary.nvim', { 'commit': '986ad71' }
 " END telescope dependencies
 
-Plug 'nvim-telescope/telescope.nvim', { 'commit': '0011b11' }
+Plug 'nvim-telescope/telescope.nvim', { 'commit': 'b5833a6' }
 
-Plug 'nvim-telescope/telescope-file-browser.nvim', { 'commit': 'e65a567' }
+Plug 'nvim-telescope/telescope-file-browser.nvim', { 'commit': 'c30fcb6' }
 
-Plug 'hrsh7th/nvim-compe', { 'commit': 'd186d73' }
+Plug 'hrsh7th/cmp-nvim-lsp', { 'commit': 'affe808' }
+Plug 'hrsh7th/cmp-buffer', { 'commit': '62fc67a' }
+Plug 'hrsh7th/cmp-path', { 'commit': '447c87c' }
+Plug 'hrsh7th/cmp-cmdline', { 'commit': 'c36ca4b' }
+Plug 'hrsh7th/nvim-cmp', { 'commit': '89df2cb' }
 
-Plug 'dyng/ctrlsf.vim', { 'commit': '2536895' }
+Plug 'dyng/ctrlsf.vim', { 'commit': '9eb13ad' }
 
 
 call plug#end()
@@ -65,29 +73,116 @@ syntax on
 filetype plugin indent on
 
 " BEGIN nvim-compe related config
-set completeopt=menuone,noselect
+set completeopt=menu,menuone,noselect
 
-let g:compe = {}
+lua <<EOF
+  -- Setup nvim-cmp.
+  local cmp = require'cmp'
 
-let g:compe.source = {}
-let g:compe.source.path = v:true
-let g:compe.source.buffer = v:true
-let g:compe.source.calc = v:true
-let g:compe.source.nvim_lsp = v:true
-let g:compe.source.nvim_lua = v:true
-let g:compe.source.vsnip = v:false
-let g:compe.source.ultisnips = v:false
-let g:compe.source.luasnip = v:false
-let g:compe.source.emoji = v:false
+  cmp.setup({
+    snippet = {
+      expand = function(args)
+        -- we leave this empty because we don't use snippets
+      end,
+    },
+    mapping = cmp.mapping.preset.insert({
+      ['<C-b>'] = cmp.mapping.scroll_docs(-4),
+      ['<C-f>'] = cmp.mapping.scroll_docs(4),
+      ['<C-Space>'] = cmp.mapping.complete(),
+      ['<C-e>'] = cmp.mapping.abort(),
+      ['<CR>'] = cmp.mapping.confirm({ select = true }), -- Accept currently selected item. Set `select` to `false` to only confirm explicitly selected items.
+    }),
+    sources = cmp.config.sources({
+      { name = 'nvim_lsp' },
+    }, {
+      { name = 'buffer' },
+    }),
+    view = {
+      entries = {
+        name = 'custom',
+        selection_order = 'near_cursor'
+      }
+    },
+  })
 
-inoremap <expr> <Tab> pumvisible() ? "\<C-n>" : "\<Tab>"
-inoremap <expr> <S-Tab> pumvisible() ? "\<C-p>" : "\<S-Tab>"
+  -- Set configuration for specific filetype.
+  cmp.setup.filetype('gitcommit', {
+    sources = cmp.config.sources({
+      { name = 'cmp_git' }, -- You can specify the `cmp_git` source if you were installed it.
+    }, {
+      { name = 'buffer' },
+    })
+  })
 
-inoremap <silent><expr> <C-Space> compe#complete()
-inoremap <silent><expr> <CR>      compe#confirm('<CR>')
+  -- Use buffer source for `/` (if you enabled `native_menu`, this won't work anymore).
+  cmp.setup.cmdline('/', {
+    mapping = cmp.mapping.preset.cmdline(),
+    sources = {
+      { name = 'buffer' }
+    }
+  })
+
+  -- Use cmdline & path source for ':' (if you enabled `native_menu`, this won't work anymore).
+  cmp.setup.cmdline(':', {
+    mapping = cmp.mapping.preset.cmdline(),
+    sources = cmp.config.sources({
+      { name = 'path' }
+    }, {
+      { name = 'cmdline' }
+    })
+  })
+EOF
 
 
-" END nvim-compe related config
+" END nvim-cmp related config
+
+" BEGIN lsp related config
+
+" Always show the signcolumn, otherwise it would shift the text each time
+" diagnostics appear/become resolved.
+if has("patch-8.1.1564")
+  " Recently vim can merge signcolumn and number column into one
+  set signcolumn=number
+else
+  set signcolumn=yes
+endif
+
+set updatetime=300
+
+lua <<EOF
+  -- Setup lspconfig.
+  local capabilities = require('cmp_nvim_lsp').update_capabilities(vim.lsp.protocol.make_client_capabilities())
+
+  require('lspconfig')['hls'].setup {
+    cmd = { "./.vim/haskell-language-server-wrapper", "--lsp" },
+    flags = { debounce_text_changes = 500, },
+    settings = {
+      haskell = {
+        plugin = {
+          ["ghcide-completions"] = {
+            config = {
+              snippetsOn = false,
+              autoExtendOn = false,
+            }
+          }
+        }
+      }
+    },
+    capabilities = capabilities,
+  }
+
+  vim.lsp.handlers["textDocument/publishDiagnostics"] = vim.lsp.with(
+    vim.lsp.diagnostic.on_publish_diagnostics, {
+      virtual_text = false,
+      underline = true,
+      signs = true,
+    }
+  )
+EOF
+
+" END lsp related config
+
+
 
 "
 " Provide a way to reload the vim setup nicely. Vim
@@ -190,9 +285,11 @@ let g:which_key_map = {
   \   'l' : [':Telescope live_grep', 'Live search with preview via :Telescope'],
   \   },
   \ 't' : {
-  \   'name' : '+nerdtree',
-  \   't' : [ ':NERDTreeToggle', 'toggle display of NERDTree'],
-  \   'f' : [ ':NERDTreeFind', 'find current file in the NERDTree window'],
+  \   'name' : '+filetree',
+  \   't' : [ ':NvimTreeToggle', 'toggle display of the file tree'],
+  \   'f' : [ ':NvimTreeFindFile', 'find current file in the file tree'],
+  \   'o' : [ ':NvimTreeFocus', 'open or focus the file tree'],
+  \   'c' : [ ':NvimTreeClose', 'close file tree'],
   \   },
   \ 'g' : {
   \   'name' : '+git',
@@ -238,7 +335,6 @@ let g:which_key_map = {
   \   'a' : ['init#code_action()', 'Open the code action menu'],
   \   'g' : ['init#go_to_definition()', 'Go to definition'],
   \   'd' : ['init#show_documentation()', 'Show documentation'],
-  \   'e' : ['init#manual_show_error_popup()', 'Show or focus error popup'],
   \   'r' : ['init#references()', 'Show references'],
   \   'i' : [':LspInfo', 'Show LSP Status Info'],
   \   't' : [':LspRestart', 'Restart LSP Server'],
@@ -246,6 +342,17 @@ let g:which_key_map = {
   \   'x' : [':LspStop', 'Stop LSP Server'],
   \   'h' : [':call chansend(g:last_terminal_chan_id, ":r\<cr>")', 'Recompile in GHCI - send :r to the terminal'],
   \   'p' : [':call chansend(g:last_terminal_chan_id, "grunt\<cr>")', 'Recompile Purescript - send grunt to the terminal'],
+  \   },
+  \ 'e' : {
+  \   'name': 'errors (in code)',
+  \   'l' : ['init#error_open_float_line()', 'Show or focus error popup for current line'],
+  \   'b' : ['init#error_open_float_buffer()', 'Show or focus error popup for entire buffer'],
+  \   'o' : ['init#error_open_list()', 'Open errors in location list'],
+  \   'c' : [':lclose', 'Close the error locations list'],
+  \   'n' : ['init#error_move_next()', 'Move to the next error'],
+  \   'p' : ['init#error_move_prev()', 'Move to the previous error'],
+  \   'h' : ['init#error_hide()', 'Hide errors rendered in buffer'],
+  \   's' : ['init#error_show()', 'Show (unhide) errors rendered in buffer'],
   \   },
   \ 'o' : {
   \   'name' : '+organize',
@@ -291,8 +398,32 @@ function! init#references()
   :lua vim.lsp.buf.references()
 endfunction
 
-function! init#manual_show_error_popup()
-  :lua vim.diagnostic.open_float({show_header = false, focusable = true})
+function! init#error_open_float_line()
+  :lua vim.diagnostic.open_float({scope = 'line', show_header = false, focusable = true, focus = true})
+endfunction
+
+function! init#error_open_float_buffer()
+  :lua vim.diagnostic.open_float({scope = 'buffer', show_header = false, focusable = true, focus = true})
+endfunction
+
+function! init#error_open_list()
+  :lua vim.diagnostic.setloclist()
+endfunction
+
+function! init#error_move_next()
+  :lua vim.diagnostic.goto_next({float = false})
+endfunction
+
+function! init#error_move_prev()
+  :lua vim.diagnostic.goto_prev({float = false})
+endfunction
+
+function! init#error_hide()
+  :lua vim.diagnostic.hide()
+endfunction
+
+function! init#error_show()
+  :lua vim.diagnostic.show()
 endfunction
 
 " vim magit installs a default binding that we prefer not to show. Unmapping
@@ -452,37 +583,53 @@ if s:truecolor || has('gui_running')
   let g:terminal_color_15='#ffffff' " white
 endif
 
-" BEGIN lsp related config
-
 lua <<EOF
-require'lspconfig'.hls.setup{
-  cmd = { "./.vim/haskell-language-server-wrapper", "--lsp" },
-  flags = { debounce_text_changes = 500, }
-}
-
-vim.lsp.handlers["textDocument/publishDiagnostics"] = vim.lsp.with(
-  vim.lsp.diagnostic.on_publish_diagnostics, {
-    virtual_text = false,
-    underline = true,
-    signs = true,
+require("nvim-tree").setup({
+  respect_buf_cwd = true,
+  diagnostics = {
+    enable = true,
+    show_on_dirs = true,
+    icons = { hint = "H", info = "I", warning = "W", error = "E" },
+  },
+  renderer = {
+    icons = {
+      symlink_arrow = " ➛ ",
+      git_placement = "after",
+      padding = "",
+      show = {
+        file = false,
+        folder = false,
+        folder_arrow = true,
+        git = true,
+      },
+      glyphs = {
+        default = "",
+        symlink = "s",
+        bookmark = "b",
+        folder = {
+          arrow_closed = "▶",
+          arrow_open = "▼",
+          default = "",
+          open = "",
+          empty = "e",
+          empty_open = "e",
+          symlink = "s",
+          symlink_open = "s",
+        },
+        git = {
+          unstaged = "•",
+          staged = "•",
+          unmerged = "•",
+          renamed = "•",
+          untracked = "•",
+          deleted = "•",
+          ignored = "•",
+        },
+      },
+    },
   }
-)
+})
 EOF
-
-" Always show the signcolumn, otherwise it would shift the text each time
-" diagnostics appear/become resolved.
-if has("patch-8.1.1564")
-  " Recently vim can merge signcolumn and number column into one
-  set signcolumn=number
-else
-  set signcolumn=yes
-endif
-
-set updatetime=300
-
-" END lsp related config
-"
-"
 
 augroup Terminal
   au!

--- a/init.vim
+++ b/init.vim
@@ -90,7 +90,7 @@ lua <<EOF
       ['<C-f>'] = cmp.mapping.scroll_docs(4),
       ['<C-Space>'] = cmp.mapping.complete(),
       ['<C-e>'] = cmp.mapping.abort(),
-      ['<CR>'] = cmp.mapping.confirm({ select = true }), -- Accept currently selected item. Set `select` to `false` to only confirm explicitly selected items.
+      ['<CR>'] = cmp.mapping.confirm({ select = false }), -- Accept currently selected item. Set `select` to `false` to only confirm explicitly selected items.
     }),
     sources = cmp.config.sources({
       { name = 'nvim_lsp' },

--- a/init.vim
+++ b/init.vim
@@ -158,6 +158,7 @@ lua <<EOF
     flags = { debounce_text_changes = 500, },
     settings = {
       haskell = {
+        formattingProvider = "fourmolu",
         plugin = {
           ["ghcide-completions"] = {
             config = {
@@ -333,6 +334,7 @@ let g:which_key_map = {
   \ 'c' : {
   \   'name' : '+code (lsp)',
   \   'a' : ['init#code_action()', 'Open the code action menu'],
+  \   'f' : ['init#code_format()', 'Format the file via the language server'],
   \   'g' : ['init#go_to_definition()', 'Go to definition'],
   \   'd' : ['init#show_documentation()', 'Show documentation'],
   \   'r' : ['init#references()', 'Show references'],
@@ -384,6 +386,10 @@ endfunction
 
 function! init#code_action()
   :lua vim.lsp.buf.code_action()
+endfunction
+
+function! init#code_format()
+  :lua vim.lsp.buf.formatting()
 endfunction
 
 function! init#go_to_definition()


### PR DESCRIPTION
This assumes Neovim 0.7.2 is being used to correctly correspond to the
lsp plugin version.

Most of the plugins were updated to the latest commit on the main
development branch. A few were updated to the the lastest tagged release
or the latest commit with a passing build.

NERDTree is no longer maintained. It has been replaced with `vim-tree`.

The completion plugin has been deprecated by its author and replaced
with a new, lua based version.

This also includes a change to no longer _automatically_ show the error
message inline for diagnostics. You can access the diagnostic via
`<SPACE>el` ("error, line"). This resolves the window display conflict
between errors and documentation.