### PR TITLE
Automatically set EDITOR if nvr is installed

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -3,7 +3,9 @@ let s:truecolor=($COLORTERM == "truecolor")
 
 " Allow shells started within nvim to detect the server surrounding them
 " (e.g. for nvr)
-let $NVIM_LISTEN_ADDRESS=v:servername
+if executable('nvr')
+  let $EDITOR='nvr -cc split --remote-wait --servername ' . v:servername
+endif
 
 if s:truecolor
   set termguicolors


### PR DESCRIPTION
This now checks if `nvr` is installed when `nvim` is started and sets
the `EDITOR` variable appropriately if so. This avoids the need for the
legacy `NVIM_LISTEN_ADDRESS` variable and does not require the user to
modify their shell config.