### PR TITLE
Checks for missing plugins at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An unassuming Neovim distribution used by Flipstone and friends
 
 * Clone the repo: `git clone git@github.com:flipstone/vimstone.git ~/.config/nvim`
 * Run `nvim`
-* Inside `nvim`, run `:PlugInstall`, then run `:SourceInitFile`
+  * Answer `y` (or just hit enter) when it asks if you want to install plugins
 
 ## Upgrading
 

--- a/init.vim
+++ b/init.vim
@@ -71,6 +71,16 @@ Plug 'dyng/ctrlsf.vim', { 'commit': '9eb13ad' }
 
 call plug#end()
 
+if len(filter(values(g:plugs), '!isdirectory(v:val.dir)'))
+  let choice = confirm("Some plugins are not installed. Install them now?", "&yes\n&no", 1)
+
+  if choice == 1
+    PlugInstall --sync
+  else
+    echo "You may see errors due to configuration that depends on plugins"
+  endif
+endif
+
 syntax on
 filetype plugin indent on
 
@@ -651,3 +661,4 @@ augroup Git
   " and to allow :q to work as expected with neovim-remote (nvr)
   au FileType gitcommit,gitrebase,gitconfig set bufhidden=delete
 augroup END
+


### PR DESCRIPTION
This adds a check to see if any plugins are not installed at startup and
offers to install them before loading the rest of the config. This
offers new users a better installation experience the first time they
launch `nvim` with `vimstone` installed.