### PR TITLE
Enables saving tab names in sessions

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -219,6 +219,7 @@ EOF
 " BEGIN taboo related config
 let g:taboo_tab_format=" |%f%m%I|"
 let g:taboo_renamed_tab_format=" |%l%m%I|"
+set sessionoptions+=tabpages,globals
 
 " END taboo related config
 


### PR DESCRIPTION
Setting `sessionoptions+=tabpages,globals` allows the Taboo plugin to
save the tab names when you use `:mksession <filename>` so that `:source
<filename>` can restore the tabs with the same names.
