### PR TITLE
Disables `neo-tree` binding to the current working directory

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -135,6 +135,9 @@ require("neo-tree").setup({
         conflict  = "💥",
       }
     }
+  },
+  filesystem = {
+    bind_to_cwd = false
   }
 })
 EOF


### PR DESCRIPTION
This plays havoc with different directories across tabs. Disabling it
seems to work fine though.
