### PR TITLE
Golang: Abide by go-fmt, do not expand tab

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -92,6 +92,7 @@ endif
 
 syntax on
 filetype plugin indent on
+autocmd FileType go set noexpandtab
 
 lua <<EOF
 require('window-picker').setup()


### PR DESCRIPTION
As can be seem in [the gofmt documentation](https://pkg.go.dev/cmd/gofmt), go uses tabs for indentation.

Because vim has `set nolist` by defualt, it's not easily visible whether spaces or tabs are in use.

By setting expandtab for go, users are therefore mixing up whitespace on gofmt compliant code.

Let's abide by the language convention and not expand tabs for Golang code.
